### PR TITLE
Improve overwriting files

### DIFF
--- a/examples/readTest/readTest.ino
+++ b/examples/readTest/readTest.ino
@@ -18,13 +18,13 @@ uint16_t OSFS::startOfEEPROM = 1;
 uint16_t OSFS::endOfEEPROM = 1024;
 
 void OSFS::readNBytes(uint16_t address, unsigned int num, byte* output) {
-	for (int i = address; i < address + num; i++) {
+	for (uint16_t i = address; i < address + num; i++) {
 		*output = EEPROM.read(i);
 		output++;
 	}
 }
 void OSFS::writeNBytes(uint16_t address, unsigned int num, const byte* input) {
-	for (int i = address; i < address + num; i++) {
+	for (uint16_t i = address; i < address + num; i++) {
 		EEPROM.update(i, *input);
 		input++;
 	}

--- a/examples/writeTest/writeTest.ino
+++ b/examples/writeTest/writeTest.ino
@@ -23,7 +23,7 @@ uint16_t OSFS::endOfEEPROM = 1024;
 
 // 3) How do I read from the medium?
 void OSFS::readNBytes(uint16_t address, unsigned int num, byte* output) {
-	for (int i = address; i < address + num; i++) {
+	for (uint16_t i = address; i < address + num; i++) {
 		*output = EEPROM.read(i);
 		output++;
 	}
@@ -31,7 +31,7 @@ void OSFS::readNBytes(uint16_t address, unsigned int num, byte* output) {
 
 // 4) How to I write to the medium?
 void OSFS::writeNBytes(uint16_t address, unsigned int num, const byte* input) {
-	for (int i = address; i < address + num; i++) {
+	for (uint16_t i = address; i < address + num; i++) {
 		EEPROM.update(i, *input);
 		input++;
 	}

--- a/src/OSFS.cpp
+++ b/src/OSFS.cpp
@@ -84,7 +84,7 @@ namespace OSFS {
 			return r;
 
 		// It is! Now get the first file header
-		int sizeRequired = sizeof(fileHeader) + size;
+		unsigned int sizeRequired = sizeof(fileHeader) + size;
 
 		// If we're overwriting an existing file, delete the existing file (if it
 		// exists)
@@ -93,7 +93,7 @@ namespace OSFS {
 		} else {
 			// If we're not, check if it already exists
 			uint16_t checkFilePointer, checkFileSize;
-			results r_check = getFileInfo(filename, checkFilePointer, checkFileSize)
+			result r_check = getFileInfo(filename, checkFilePointer, checkFileSize);
 
 			if (r_check != result::FILE_NOT_FOUND)
 				return result::FILE_ALREADY_EXISTS;
@@ -132,7 +132,7 @@ namespace OSFS {
 			// If this is a deleted file, see if we can fit our file here
 			if (isDeletedFile(workingHeader)) {
 				// It is. Is the space large enough for us?
-				int deletedSpace = workingHeader.nextFile - workingAddress;
+				unsigned int deletedSpace = workingHeader.nextFile - workingAddress;
 				if (deletedSpace >= sizeRequired) {
 					// Save the location for writing and quit the loop
 					writeAddress = workingAddress;
@@ -278,7 +278,7 @@ namespace OSFS {
 		if (address < startOfEEPROM || address > endOfEEPROM) return result::UNCAUGHT_OOR;
 		if (address + num < startOfEEPROM || address + num > endOfEEPROM) return result::UNCAUGHT_OOR;
 
-		writeNBytes(address, num, input);
+		writeNBytes(address, num, (byte*)input);
 
 		return result::NO_ERROR;
 	}
@@ -288,7 +288,7 @@ namespace OSFS {
 		if (address < startOfEEPROM || address > endOfEEPROM) return result::UNCAUGHT_OOR;
 		if (address + num < startOfEEPROM || address + num > endOfEEPROM) return result::UNCAUGHT_OOR;
 
-		readNBytes(address, num, output);
+		readNBytes(address, num, (byte*)output);
 
 		return result::NO_ERROR;
 	}

--- a/src/OSFS.cpp
+++ b/src/OSFS.cpp
@@ -89,14 +89,19 @@ namespace OSFS {
 		// If we're overwriting an existing file, delete the existing file (if it
 		// exists)
 		if (overwrite) {
-			deleteFile(filename);
+			result r_delete = deleteFile(filename);
+			if (r_delete != result::NO_ERROR && r_delete != result::FILE_NOT_FOUND)
+				return r_delete;
 		} else {
 			// If we're not, check if it already exists
 			uint16_t checkFilePointer, checkFileSize;
 			result r_check = getFileInfo(filename, checkFilePointer, checkFileSize);
 
-			if (r_check != result::FILE_NOT_FOUND)
+			if (r_check == result::NO_ERROR)
 				return result::FILE_ALREADY_EXISTS;
+			if (r_check != result::FILE_NOT_FOUND)
+				return r_check;
+			// r_check == FILE_NOT_FOUND
 		}
 
 		fileHeader workingHeader;

--- a/src/OSFS.cpp
+++ b/src/OSFS.cpp
@@ -106,13 +106,24 @@ namespace OSFS {
 
 			// Quit if it has the same name and isn't deleted
 			if (!isDeletedFile(workingHeader) && 0 == strncmp(workingHeader.fileID, newHeader.fileID, 11)) {
-				// Error if different sizes or overwrite == false
-				if (size != workingHeader.fileSize || overwrite == false)
+				// Error if overwrite == false
+				if (!overwrite)
+				{
 					return result::FILE_ALREADY_EXISTS;
+				}
+				else if (size != workingHeader.fileSize)
+				{
+					//even though overwrite is true, this isn't the same filesize.  Therefore... delete it and keep going.
+					deleteFiledt(filename);
+				}
+				else
+				{
 
-				// else overwrite it
-				writeAddress = workingAddress;
-				break;
+					// Overwriting is possible: user asked for it, and the sizes are the same
+					writeAddress = workingAddress;
+					break;
+
+				}
 			}
 
 			// If there's no next file, calculate the start of the spare space and break the loop

--- a/src/OSFS.h
+++ b/src/OSFS.h
@@ -134,6 +134,10 @@ namespace OSFS {
 	 *                       be ignored, less chars will be padded to 11.
 	 * @param      data      Pointer to the data to be stored.
 	 * @param      size      Number of bytes to store, starting at `data`.
+	 * @param      overwrite Overwrite the named file is it is present. Note that 
+	                         if you attempt to overwrite an existing file with a larger one
+	                         but there is insufficient space, the original file will still
+	                         be deleted. 
 	 *
 	 * @return     Error status.
 	 */
@@ -149,6 +153,10 @@ namespace OSFS {
 	 * @param      filename  The filename. Should be 11 chars long. More chars will
 	 *                       be ignored, less chars will be padded to 11.
 	 * @param[in]  buf       The variable to be stored
+	 * @param      overwrite Overwrite the named file is it is present. Note that 
+	                         if you attempt to overwrite an existing file with a larger one
+	                         but there is insufficient space, the original file will still
+	                         be deleted. 
 	 *
 	 * @tparam     T         Type to be stored (autodetected)
 	 *

--- a/src/OSFS.h
+++ b/src/OSFS.h
@@ -233,7 +233,7 @@ namespace OSFS {
 	void padFilename(const char * filenameIn, char * filenameOut);
 
 	inline bool isDeletedFile(fileHeader workingHeader) {
-		return workingHeader.flags && 1<<DELBIT;
+		return workingHeader.flags & (1<<DELBIT);
 	}
 
 }


### PR DESCRIPTION
Changes from @dHutchings in PR #4:

> Previously, if you tried to write a new file, while overwriting a
> previous one, it would return the FILE_ALREADY_EXISTS error if the
> filesizes weren't the same.
> 
> This doesn't make sense, espescially since the user explititly set the
> overwrite flag true.
> 
> This new behaviour returns FILE_ALREADY_EXISTS only if overwrite is
> false.
> 
> If overwrite is true and it encounters an identically named file, it
> either uses it (if the sizes are identical) or deletes it and moves on.

(cherry picked from commit f62b6cb050f94f5e71fc10d63834acd2827a75f0)